### PR TITLE
package.json 의 homepage 값 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,5 @@
   "bugs": {
     "url": "https://github.com/depromeet/final-team9-frontend/issues"
   },
-  "homepage": "https://github.com/depromeet/final-team9-frontend#readme"
+  "homepage": "http://jibsuni.depromeet.com"
 }


### PR DESCRIPTION
### AS-IS
- 기존 homepage 필드는 `https://github.com/depromeet/final-team9-frontend#readme` 와 같이 github 주소를 바라보고있어서, production 환경에서 정적파일을 잘 못찾음 (`depromeet/final-team9-frontend` 가 path 에 prefix 로 추가됨)

### TO-BE
- homepage 필드를 `http://jibsuni.depromeet.com` 으로 수정합니다